### PR TITLE
Do not dump nil responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 vendor
+output
+fixtures
 *.txt
+coverage.out
+.DS_Store
+example/out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+go:
+    - "1.11.x"
+    - "1.10.x"
+
+before_install:
+  - make prepare
+
+script:
+    - make

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+DEP_VERSION=0.5.0
+OS := $(shell uname | tr '[:upper:]' '[:lower:]')
+
+all: deps test
+
+prepare:
+	@echo "Installing dep..."
+	@curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-${OS}-amd64 -o ${GOPATH}/bin/dep
+	@chmod a+x ${GOPATH}/bin/dep
+
+deps:
+	dep ensure -v
+	dep status
+
+test:
+	@mkdir -p fixtures
+	go test -cover

--- a/spew.go
+++ b/spew.go
@@ -135,8 +135,10 @@ func (t *Transport) basicDump(name string, req *http.Request, resp *http.Respons
 	in.Write(dump)
 
 	writeHeader(in, "Response")
-	dump2, _ := httputil.DumpResponse(resp, true)
-	in.Write(dump2)
+	if resp != nil {
+		dump2, _ := httputil.DumpResponse(resp, true)
+		in.Write(dump2)
+	}
 
 	writeHeader(in, "error")
 	if err != nil {

--- a/spew_test.go
+++ b/spew_test.go
@@ -1,0 +1,87 @@
+package spew
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/devopsfaith/krakend/logging"
+	"github.com/devopsfaith/krakend/transport/http/client"
+)
+
+var outputFolder = "./fixtures"
+
+func TestTransport_nilResponse(t *testing.T) {
+	expErr := errors.New("expect me")
+
+	client := newClientFactory(nil, expErr)(context.Background())
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	res, err := client.Do(req)
+	if res != nil {
+		t.Errorf("unexpected response: %v", res)
+	}
+	if err == nil || err.Error() != "Get http://example.com: expect me" {
+		t.Errorf("unexpected error. have: %v, want: %v", err, expErr)
+	}
+}
+
+func TestTransport_nilResponseBody(t *testing.T) {
+	expectedResponse := &http.Response{
+		StatusCode: 200,
+	}
+
+	client := newClientFactory(expectedResponse, nil)(context.Background())
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	res, err := client.Do(req)
+	if res != expectedResponse {
+		t.Errorf("unexpected response. have: %v, want: %v", res, expectedResponse)
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestTransport_nilError(t *testing.T) {
+	expectedResponse := &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString("response body")),
+	}
+
+	client := newClientFactory(expectedResponse, nil)(context.Background())
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	res, err := client.Do(req)
+	if res != expectedResponse {
+		t.Errorf("unexpected response. have: %v, want: %v", res, expectedResponse)
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func newClientFactory(resp *http.Response, err error) client.HTTPClientFactory {
+	logger, _ := logging.NewLogger("DEBUG", ioutil.Discard, "")
+	cf := func(_ context.Context) *http.Client {
+		return &http.Client{
+			Transport: &mockedRoundTripper{
+				resp: resp,
+				err:  err,
+			},
+		}
+	}
+	return ClientFactory(logger, cf, outputFolder)
+}
+
+type mockedRoundTripper struct {
+	err  error
+	resp *http.Response
+}
+
+func (m *mockedRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return m.resp, m.err
+}


### PR DESCRIPTION
When dealing with nil responses, dumping the response causes a panic due to https://golang.org/src/net/http/httputil/dump.go#L284